### PR TITLE
fix for 2.10 stacking & patch for lit match stacking being broken

### DIFF
--- a/BetterStacking/Better-Stacking.csproj
+++ b/BetterStacking/Better-Stacking.csproj
@@ -27,7 +27,7 @@
 	<!--This is the of packages that the mod references.-->
 	<ItemGroup>
 		<!--This package contains almost everything a person could possibly need to reference while modding.-->
-		<PackageReference Include="ds5678.Modding.TLD.Il2CppAssemblies.Windows" Version="2.7.0" />
+		<PackageReference Include="ds5678.Modding.TLD.Il2CppAssemblies.Windows" Version="2.10.0" />
 		<!--The package version here in this template may be outdated and need to be updated. Visual Studio can update package versions automatically.-->
 		<!--If the mod references any other mods (such as ModSettings), that NuGet package will also need to be listed here.-->
 	</ItemGroup>

--- a/BetterStacking/Patches.cs
+++ b/BetterStacking/Patches.cs
@@ -69,7 +69,7 @@ namespace BetterStacking
             /// <param name="normalizedCondition"></param>
             /// <param name="numUnits"></param>
             /// <param name="existingGearItem"></param>
-            internal static void Prefix(GearItem gearToAdd, float normalizedCondition, int numUnits, ref GearItem existingGearItem)
+            internal static void Prefix(GearItem gearToAdd, float normalizedCondition, int numUnits, ref GearItem? existingGearItem, ref bool __runOriginal)
             {
 
                 // if the item is ruined we (do nothing)
@@ -85,13 +85,21 @@ namespace BetterStacking
                 }
 
                 // get the closest match stackable from player inventory
-                GearItem targetStack = GameManager.GetInventoryComponent().GetClosestMatchStackable(gearToAdd.GearItemData, normalizedCondition);
+                GearItem targetStack = StackableItem.GetClosestMatchStackable(GameManager.GetInventoryComponent().m_Items, gearToAdd, normalizedCondition);
 
                 // if we can't merge this item/stack (do nothing)
                 if (!CanBeMerged(targetStack, gearToAdd))
                 {
                     return;
                 }
+
+				//patch for lit matches breaking the stacks
+				if (gearToAdd.IsLitMatch() || targetStack.IsLitMatch())
+				{
+					__runOriginal = false;
+					existingGearItem = null;
+				}
+
 
                 // if the item is stackable perform the merge changed
                 if (targetStack.m_StackableItem != null)

--- a/BetterStacking/Properties/BuildInfo.cs
+++ b/BetterStacking/Properties/BuildInfo.cs
@@ -6,7 +6,7 @@
         public const string Description = "A mod for making items stack neater."; // Description for the Mod.  (Set as null if none)
         public const string Author = "WulfMarius, ds5678"; // Author of the Mod.  (MUST BE SET)
         public const string Company = null; // Company that made the Mod.  (Set as null if none)
-        public const string Version = "5.0.0"; // Version of the Mod.  (MUST BE SET)
+        public const string Version = "5.0.1"; // Version of the Mod.  (MUST BE SET)
         public const string DownloadLink = null; // Download Link for the Mod.  (Set as null if none)
     }
 }


### PR DESCRIPTION
Lit match patch should be fine even if/when HL fix the issue as it targets either stack being "Lit" and nothing else.